### PR TITLE
feat: 구매 요청 기능 추가

### DIFF
--- a/api/src/main/java/com/carrotzmarket/api/ApiApplication.java
+++ b/api/src/main/java/com/carrotzmarket/api/ApiApplication.java
@@ -2,8 +2,9 @@ package com.carrotzmarket.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class, scanBasePackages = {"com.carrotzmarket.db", "com.carrotzmarket.api"})
 public class ApiApplication {
 
     public static void main(String[] args) {

--- a/api/src/main/java/com/carrotzmarket/api/common/config/JpaConfig.java
+++ b/api/src/main/java/com/carrotzmarket/api/common/config/JpaConfig.java
@@ -1,0 +1,11 @@
+package com.carrotzmarket.api.common.config;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EntityScan(basePackages = "com.carrotzmarket.db")
+@EnableJpaRepositories(basePackages = "com.carrotzmarket.db")
+public class JpaConfig {
+}

--- a/api/src/main/java/com/carrotzmarket/api/common/error/TransactionErrorCode.java
+++ b/api/src/main/java/com/carrotzmarket/api/common/error/TransactionErrorCode.java
@@ -1,0 +1,16 @@
+package com.carrotzmarket.api.common.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum TransactionErrorCode implements ErrorCodeInterface {
+    TRANSACTION_NOT_FOUND(400, 1500, "해당 거래정보를 찾을 수 없습니다."),
+    INVALID_TRANSACTION_STATUS_CHANGE(400, 1501, "거래가 완료되었거나 취소된 거래의 상태는 변경할 수 없습니다");
+
+    private final Integer httpStatusCode;
+    private final Integer errorCode;
+    private final String description;
+
+}

--- a/api/src/main/java/com/carrotzmarket/api/domain/transaction/controller/ProductTransactionController.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/transaction/controller/ProductTransactionController.java
@@ -1,0 +1,21 @@
+package com.carrotzmarket.api.domain.transaction.controller;
+
+import com.carrotzmarket.api.domain.transaction.dto.PurchaseRequest;
+import com.carrotzmarket.api.domain.transaction.service.ProductTransactionService;
+import com.carrotzmarket.db.transaction.ProductTransactionEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProductTransactionController {
+
+    private final ProductTransactionService service;
+
+    @PostMapping("/transaction")
+    public ProductTransactionEntity createTransaction(@RequestBody PurchaseRequest request) {
+        return service.createTransaction(request);
+    }
+}

--- a/api/src/main/java/com/carrotzmarket/api/domain/transaction/converter/ProductTransactionConverter.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/transaction/converter/ProductTransactionConverter.java
@@ -1,0 +1,26 @@
+package com.carrotzmarket.api.domain.transaction.converter;
+
+import com.carrotzmarket.api.domain.transaction.dto.PurchaseRequest;
+import com.carrotzmarket.db.transaction.ProductTransactionEntity;
+import com.carrotzmarket.db.transaction.TransactionStatus;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProductTransactionConverter {
+    public ProductTransactionEntity toEntity(PurchaseRequest request) {
+        return Optional.ofNullable(request)
+                .map(it -> {
+                    return ProductTransactionEntity.builder()
+                            .buyerId(request.getBuyerId())
+                            .sellerId(request.getSellerId())
+                            .productId(request.getProductId())
+                            .transactionDate(request.getTransactionDate())
+                            .tradingHours(request.getTradingHours())
+                            .tradingPlace(request.getTradingPlace())
+                            .status(TransactionStatus.IN_PROGRESS)
+                            .hasReview(false)
+                            .build();
+                }).orElseThrow(() -> new IllegalStateException("예외 발생"));
+    }
+}

--- a/api/src/main/java/com/carrotzmarket/api/domain/transaction/dto/PurchaseRequest.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/transaction/dto/PurchaseRequest.java
@@ -1,0 +1,16 @@
+package com.carrotzmarket.api.domain.transaction.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class PurchaseRequest {
+    private Long productId;
+    private Long buyerId;
+    private Long sellerId;
+
+    private LocalDate transactionDate;
+    private LocalDateTime tradingHours;
+    private String tradingPlace;
+}

--- a/api/src/main/java/com/carrotzmarket/api/domain/transaction/repository/ProductTransactionRepository.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/transaction/repository/ProductTransactionRepository.java
@@ -1,0 +1,18 @@
+package com.carrotzmarket.api.domain.transaction.repository;
+
+import com.carrotzmarket.db.transaction.ProductTransactionEntity;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductTransactionRepository {
+
+    private final EntityManager em;
+
+    public ProductTransactionEntity save(ProductTransactionEntity productTransaction) {
+        em.persist(productTransaction);
+        return productTransaction;
+    }
+}

--- a/api/src/main/java/com/carrotzmarket/api/domain/transaction/service/ProductTransactionService.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/transaction/service/ProductTransactionService.java
@@ -1,0 +1,31 @@
+package com.carrotzmarket.api.domain.transaction.service;
+
+import com.carrotzmarket.api.domain.transaction.converter.ProductTransactionConverter;
+import com.carrotzmarket.api.domain.transaction.dto.PurchaseRequest;
+import com.carrotzmarket.api.domain.transaction.repository.ProductTransactionRepository;
+import com.carrotzmarket.db.transaction.ProductTransactionEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductTransactionService {
+
+    private final ProductTransactionRepository repository;
+    private final ProductTransactionConverter converter;
+
+    /**
+     * TODO : createTransaction() 구매자 ID, 판매자 ID, 상품 ID 유효성 검증
+     * 구매자 ID, 판매자 ID, 상품 ID 각각 조회
+     * 상품이 존재 하지 않거나, 유효하지 않는 사용자 ID가 요청된 경우 예외 발생
+     */
+
+    @Transactional(readOnly = true)
+    public ProductTransactionEntity createTransaction(PurchaseRequest request) {
+        ProductTransactionEntity entity = converter.toEntity(request);
+        return repository.save(entity);
+    }
+
+}

--- a/api/src/test/java/com/carrotzmarket/api/domain/transaction/service/ProductTransactionServiceTest.java
+++ b/api/src/test/java/com/carrotzmarket/api/domain/transaction/service/ProductTransactionServiceTest.java
@@ -1,0 +1,78 @@
+package com.carrotzmarket.api.domain.transaction.service;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.carrotzmarket.api.domain.transaction.converter.ProductTransactionConverter;
+import com.carrotzmarket.api.domain.transaction.dto.PurchaseRequest;
+import com.carrotzmarket.api.domain.transaction.repository.ProductTransactionRepository;
+import com.carrotzmarket.db.transaction.ProductTransactionEntity;
+import com.carrotzmarket.db.transaction.TransactionStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProductTransactionServiceTest {
+
+    @Mock
+    ProductTransactionRepository repository;
+
+    @Mock
+    ProductTransactionConverter converter;
+
+    @InjectMocks
+    ProductTransactionService service;
+
+    @Test
+    void 사용자가_구매요청을_보내면_거래내역이_생성된다() {
+        // given
+        PurchaseRequest request = createRequest();
+        ProductTransactionEntity mockEntity = createEntity(request);
+
+        when(converter.toEntity(any(PurchaseRequest.class))).thenReturn(mockEntity);
+        when(repository.save(any(ProductTransactionEntity.class))).thenReturn(mockEntity);
+
+        // when
+        ProductTransactionEntity result = service.createTransaction(request);
+
+        // then
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result.getBuyerId()).isEqualTo(mockEntity.getBuyerId());
+        Assertions.assertThat(result.getSellerId()).isEqualTo(mockEntity.getSellerId());
+        Assertions.assertThat(result.getProductId()).isEqualTo(mockEntity.getProductId());
+        Assertions.assertThat(result.getTransactionDate()).isEqualTo(mockEntity.getTransactionDate());
+        Assertions.assertThat(result.getTradingPlace()).isEqualTo(mockEntity.getTradingPlace());
+        Assertions.assertThat(result.getStatus()).isEqualTo(mockEntity.getStatus());
+    }
+
+    private static ProductTransactionEntity createEntity(PurchaseRequest request) {
+        return ProductTransactionEntity.builder()
+                .buyerId(request.getBuyerId())
+                .sellerId(request.getSellerId())
+                .productId(request.getProductId())
+                .transactionDate(request.getTransactionDate())
+                .tradingHours(request.getTradingHours())
+                .tradingPlace(request.getTradingPlace())
+                .status(TransactionStatus.IN_PROGRESS)
+                .hasReview(false)
+                .build();
+    }
+
+    private static PurchaseRequest createRequest() {
+        PurchaseRequest request = new PurchaseRequest();
+        request.setProductId(1L);
+        request.setSellerId(1L);
+        request.setBuyerId(2L);
+        request.setTransactionDate(LocalDate.now());
+        request.setTradingHours(LocalDateTime.now());
+        request.setTradingPlace("서울시");
+        return request;
+    }
+}

--- a/db/src/main/java/com/carrotzmarket/db/transaction/ProductTransactionEntity.java
+++ b/db/src/main/java/com/carrotzmarket/db/transaction/ProductTransactionEntity.java
@@ -1,0 +1,43 @@
+package com.carrotzmarket.db.transaction;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "product_transaction")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter @Setter
+public class ProductTransactionEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long productId;
+
+    private Long sellerId;
+
+    private Long buyerId;
+
+    @Enumerated(EnumType.STRING)
+    private TransactionStatus status;
+
+    private Boolean hasReview;
+
+    private LocalDate transactionDate;
+    private LocalDateTime tradingHours;
+    private String tradingPlace;
+}

--- a/db/src/main/java/com/carrotzmarket/db/transaction/TransactionStatus.java
+++ b/db/src/main/java/com/carrotzmarket/db/transaction/TransactionStatus.java
@@ -1,0 +1,8 @@
+package com.carrotzmarket.db.transaction;
+
+import lombok.Getter;
+
+@Getter
+public enum TransactionStatus {
+    IN_PROGRESS, RESERVED ,COMPLETED, CANCELED;
+}


### PR DESCRIPTION
## 수정사항

### 1. 기능 구현
- 구매 요청 데이터를 처리하는 API 추가:
  - Endpoint: `/transaction`
  - HTTP Method: POST
  - Request Body: PurchaseRequest
  - Response: 저장된 ProductTransactionEntity 반환
- ProductTransactionService에 구매 요청 처리 로직 구현:
  - PurchaseRequest를 ProductTransactionEntity로 변환 (ProductTransactionConverter 사용).
  - Repository를 통해 DB에 저장.

### 2. DTO 추가
- PurchaseRequest: 구매 요청 데이터를 담는 DTO.
- `buyerId`, `sellerId`, `productId`, `transactionDate`, `tradingHours`, `tradingPlace` 필드 포함.
- 데이터 유효성 검사를 위한 로직 추가.

### 3. 예외 처리
- 잘못된 요청 데이터로 인해 변환이 실패할 경우 `API exception` 발생.
- DB 저장 실패 시 DataAccessException 발생 처리.

<br>

## 주요 파일 변경

### Controller
- ProductTransactionController.java
- /transaction API 구현.
### Service
- ProductTransactionService.java
- 구매 요청 처리 로직 구현.
### Converter
- ProductTransactionConverter.java
- DTO를 Entity로 변환하는 메서드 추가.
### Repository
- ProductTransactionRepository.java
- JPA를 사용해 데이터 저장 기능 추가.

<br>

## 실행결과
![image](https://github.com/user-attachments/assets/df186712-5e36-49ab-88de-f29a41d3688b)
![image](https://github.com/user-attachments/assets/2ec78926-7fd6-423f-9699-8c164837b4ac)


Close: #23
