### PR TITLE
판매 내역 조회 기능 추가

### DIFF
--- a/api/src/main/java/com/carrotzmarket/api/domain/transaction/controller/ProductTransactionController.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/transaction/controller/ProductTransactionController.java
@@ -30,4 +30,13 @@ public class ProductTransactionController {
     public List<ProductTransactionEntity> getPurchaseHistory(@PathVariable("id") Long userId) {
         return service.findAllPurchaseHistory(userId);
     }
+
+    /**
+     * TODO : 쿼리 파라미터 UserId를 받기 보다 세션을 이용하여 UserId를 받아올 수 있도록 수정
+     */
+    @GetMapping("/transaction/history/sales/{id}")
+    public List<ProductTransactionEntity> getSalesHistory(@PathVariable("id") Long userId) {
+        return service.findAllSalesHistory(userId);
+    }
+
 }

--- a/api/src/main/java/com/carrotzmarket/api/domain/transaction/repository/ProductTransactionRepository.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/transaction/repository/ProductTransactionRepository.java
@@ -22,4 +22,10 @@ public class ProductTransactionRepository {
                 .setParameter("id", id)
                 .getResultList();
     }
+
+    public List<ProductTransactionEntity> findAllSalesHistoryByUserId(Long id) {
+        return em.createQuery("SELECT P FROM ProductTransactionEntity P WHERE P.sellerId = :id AND P.status = 'COMPLETED'", ProductTransactionEntity.class)
+                .setParameter("id", id)
+                .getResultList();
+    }
 }

--- a/api/src/main/java/com/carrotzmarket/api/domain/transaction/service/ProductTransactionService.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/transaction/service/ProductTransactionService.java
@@ -33,5 +33,9 @@ public class ProductTransactionService {
         return repository.findAllPurchaseHistoryByUserId(userId);
     }
 
+    public List<ProductTransactionEntity> findAllSalesHistory(Long userId) {
+        return repository.findAllSalesHistoryByUserId(userId);
+    }
+
 
 }


### PR DESCRIPTION
## 추가사항
- 사용자의 ID를 통해 거래가 완료된 판매 내역을 조회하는 기능 추가
- 거래가 완료되지 않은 판매 내역은 조회되지 않도록 구현
- 판매 내역 조회를 위한 테스트 코드 작성
  - 거래가 완료된 판매 내역만 반환되는지 검증
  - 거래가 완료되지 않은 판매 내역이 포함되지 않음을 검증
