### PR TITLE
feat: 거래 내역 상태 변경 및 상품 상태 동기화 기능 추가

### DIFF
--- a/api/src/main/java/com/carrotzmarket/api/common/error/ProductErrorCode.java
+++ b/api/src/main/java/com/carrotzmarket/api/common/error/ProductErrorCode.java
@@ -1,0 +1,14 @@
+package com.carrotzmarket.api.common.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ProductErrorCode implements ErrorCodeInterface{
+    PRODUCT_NOT_FOUND(400, 1300, "해당 상품을 찾을 수 없습니다.");
+
+    private final Integer httpStatusCode;
+    private final Integer errorCode;
+    private final String description;
+}

--- a/api/src/main/java/com/carrotzmarket/api/common/error/TransactionErrorCode.java
+++ b/api/src/main/java/com/carrotzmarket/api/common/error/TransactionErrorCode.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 @Getter
 public enum TransactionErrorCode implements ErrorCodeInterface {
     TRANSACTION_NOT_FOUND(400, 1500, "해당 거래정보를 찾을 수 없습니다."),
-    INVALID_TRANSACTION_STATUS_CHANGE(400, 1501, "거래가 완료되었거나 취소된 거래의 상태는 변경할 수 없습니다");
+    INVALID_TRANSACTION_STATUS_CHANGE(400, 1501, "거래가 완료되었거나 취소된 거래의 상태는 변경할 수 없습니다"),
+    DUPLICATE_TRANSACTION_STATUS_CHANGE(400, 1502, "변경하려는 상태와 현재 상태가 동일합니다."),
+    ONLY_SELLER_CAN_CHANGE_STATUS(400, 1503, "상품의 상태는 판매자만 변경할 수 있습니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;

--- a/api/src/main/java/com/carrotzmarket/api/domain/transaction/controller/ProductTransactionController.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/transaction/controller/ProductTransactionController.java
@@ -1,6 +1,7 @@
 package com.carrotzmarket.api.domain.transaction.controller;
 
 import com.carrotzmarket.api.domain.transaction.dto.PurchaseRequest;
+import com.carrotzmarket.api.domain.transaction.dto.TransactionStatusUpdateRequest;
 import com.carrotzmarket.api.domain.transaction.service.ProductTransactionService;
 import com.carrotzmarket.db.transaction.ProductTransactionEntity;
 import java.util.List;
@@ -9,6 +10,7 @@ import org.aspectj.weaver.ast.Literal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -37,6 +39,11 @@ public class ProductTransactionController {
     @GetMapping("/transaction/history/sales/{id}")
     public List<ProductTransactionEntity> getSalesHistory(@PathVariable("id") Long userId) {
         return service.findAllSalesHistory(userId);
+    }
+
+    @PutMapping("/transaction")
+    public ProductTransactionEntity updateTransaction(@RequestBody TransactionStatusUpdateRequest request) {
+        return service.updateTransaction(request);
     }
 
 }

--- a/api/src/main/java/com/carrotzmarket/api/domain/transaction/converter/ProductTransactionConverter.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/transaction/converter/ProductTransactionConverter.java
@@ -1,20 +1,26 @@
 package com.carrotzmarket.api.domain.transaction.converter;
 
+import com.carrotzmarket.api.domain.product.service.ProductService;
 import com.carrotzmarket.api.domain.transaction.dto.PurchaseRequest;
 import com.carrotzmarket.db.transaction.ProductTransactionEntity;
 import com.carrotzmarket.db.transaction.TransactionStatus;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class ProductTransactionConverter {
+
+    private final ProductService productService;
+
     public ProductTransactionEntity toEntity(PurchaseRequest request) {
         return Optional.ofNullable(request)
                 .map(it -> {
                     return ProductTransactionEntity.builder()
                             .buyerId(request.getBuyerId())
                             .sellerId(request.getSellerId())
-                            .productId(request.getProductId())
+                            .product(productService.getProductById(request.getProductId()).get())
                             .transactionDate(request.getTransactionDate())
                             .tradingHours(request.getTradingHours())
                             .tradingPlace(request.getTradingPlace())

--- a/api/src/main/java/com/carrotzmarket/api/domain/transaction/dto/TransactionStatusUpdateRequest.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/transaction/dto/TransactionStatusUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.carrotzmarket.api.domain.transaction.dto;
+
+import com.carrotzmarket.db.transaction.TransactionStatus;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TransactionStatusUpdateRequest {
+    private Long productId;
+    private Long authorId;
+    private TransactionStatus status;
+
+}

--- a/api/src/main/java/com/carrotzmarket/api/domain/transaction/repository/ProductTransactionRepository.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/transaction/repository/ProductTransactionRepository.java
@@ -1,8 +1,10 @@
 package com.carrotzmarket.api.domain.transaction.repository;
 
+import com.carrotzmarket.db.product.ProductEntity;
 import com.carrotzmarket.db.transaction.ProductTransactionEntity;
 import jakarta.persistence.EntityManager;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,9 +14,19 @@ public class ProductTransactionRepository {
 
     private final EntityManager em;
 
+    /**
+     * TODO : 사용자가 동일한 상품에 대해 구매요청 시 예외 던지기
+     */
     public ProductTransactionEntity save(ProductTransactionEntity productTransaction) {
         em.persist(productTransaction);
         return productTransaction;
+    }
+
+    public Optional<ProductTransactionEntity> findTransactionByProductIdAndAuthorId(Long productId, Long authorId) {
+        return em.createQuery("SELECT P FROM ProductTransactionEntity P WHERE P.sellerId = :authorId AND P.product.id = :productId", ProductTransactionEntity.class)
+                .setParameter("authorId", authorId)
+                .setParameter("productId", productId)
+                .getResultStream().findFirst();
     }
 
     public List<ProductTransactionEntity> findAllPurchaseHistoryByUserId(Long id) {

--- a/api/src/main/java/com/carrotzmarket/api/domain/transaction/service/ProductTransactionService.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/transaction/service/ProductTransactionService.java
@@ -1,21 +1,40 @@
 package com.carrotzmarket.api.domain.transaction.service;
 
+import static com.carrotzmarket.api.common.error.TransactionErrorCode.DUPLICATE_TRANSACTION_STATUS_CHANGE;
+import static com.carrotzmarket.api.common.error.TransactionErrorCode.ONLY_SELLER_CAN_CHANGE_STATUS;
+import static com.carrotzmarket.api.common.error.TransactionErrorCode.TRANSACTION_NOT_FOUND;
+import static com.carrotzmarket.db.product.ProductStatus.ON_SALE;
+import static com.carrotzmarket.db.product.ProductStatus.SOLD_OUT;
+import static com.carrotzmarket.db.transaction.TransactionStatus.CANCELED;
+import static com.carrotzmarket.db.transaction.TransactionStatus.COMPLETED;
+import static com.carrotzmarket.db.transaction.TransactionStatus.IN_PROGRESS;
+import static com.carrotzmarket.db.transaction.TransactionStatus.RESERVED;
+
+import com.carrotzmarket.api.common.exception.ApiException;
+import com.carrotzmarket.api.domain.product.service.ProductService;
 import com.carrotzmarket.api.domain.transaction.converter.ProductTransactionConverter;
 import com.carrotzmarket.api.domain.transaction.dto.PurchaseRequest;
+import com.carrotzmarket.api.domain.transaction.dto.TransactionStatusUpdateRequest;
 import com.carrotzmarket.api.domain.transaction.repository.ProductTransactionRepository;
+import com.carrotzmarket.db.product.ProductEntity;
+import com.carrotzmarket.db.product.ProductStatus;
 import com.carrotzmarket.db.transaction.ProductTransactionEntity;
+import com.carrotzmarket.db.transaction.TransactionStatus;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class ProductTransactionService {
 
     private final ProductTransactionRepository repository;
     private final ProductTransactionConverter converter;
+    private final ProductService productService;
 
     /**
      * TODO : createTransaction() 구매자 ID, 판매자 ID, 상품 ID 유효성 검증
@@ -23,10 +42,26 @@ public class ProductTransactionService {
      * 상품이 존재 하지 않거나, 유효하지 않는 사용자 ID가 요청된 경우 예외 발생
      */
 
-    @Transactional(readOnly = true)
+    @Transactional(readOnly = false)
     public ProductTransactionEntity createTransaction(PurchaseRequest request) {
         ProductTransactionEntity entity = converter.toEntity(request);
         return repository.save(entity);
+    }
+
+    @Transactional(readOnly = false)
+    public ProductTransactionEntity updateTransaction(TransactionStatusUpdateRequest request) {
+
+        // 거래 상태 변경을 요청하는 사용자가 판매자인지 확인
+        ProductEntity product = productService.getProductById(request.getProductId()).orElseThrow();
+        validateSellerAuthorization(product, request.getAuthorId());
+
+        // 상품의 ID와 판매자의 ID로 거래내역을 조회
+        ProductTransactionEntity transaction = repository.findTransactionByProductIdAndAuthorId(product.getId(), request.getAuthorId()).orElseThrow(() -> new ApiException(TRANSACTION_NOT_FOUND));
+
+        // 거래 상태 변경
+        changeTransactionStatus(transaction, product, request.getStatus());
+
+        return transaction;
     }
 
     public List<ProductTransactionEntity> findAllPurchaseHistory(Long userId) {
@@ -37,5 +72,36 @@ public class ProductTransactionService {
         return repository.findAllSalesHistoryByUserId(userId);
     }
 
+    private void changeTransactionStatus(ProductTransactionEntity entity, ProductEntity product, TransactionStatus status) {
+        if (entity.getStatus().equals(status)) {
+            throw new ApiException(DUPLICATE_TRANSACTION_STATUS_CHANGE);
+        }
+
+        if (status.equals(RESERVED)) {
+            product.setStatus(ProductStatus.RESERVED);
+            entity.setStatus(RESERVED);
+        }
+
+        if (status.equals(COMPLETED)) {
+            product.setStatus(SOLD_OUT);
+            entity.setStatus(COMPLETED);
+        }
+
+        if (status.equals(IN_PROGRESS)) {
+            product.setStatus(ON_SALE);
+            entity.setStatus(IN_PROGRESS);
+        }
+
+        if (status.equals(CANCELED)) {
+            product.setStatus(ON_SALE);
+            entity.setStatus(CANCELED);
+        }
+    }
+
+    private void validateSellerAuthorization(ProductEntity product, Long authorId) {
+        if (!product.getUserId().equals(authorId)) {
+            throw new ApiException(ONLY_SELLER_CAN_CHANGE_STATUS);
+        }
+    }
 
 }

--- a/db/src/main/java/com/carrotzmarket/db/product/ProductEntity.java
+++ b/db/src/main/java/com/carrotzmarket/db/product/ProductEntity.java
@@ -1,9 +1,12 @@
 package com.carrotzmarket.db.product;
 
 import com.carrotzmarket.db.product.ProductStatus;
+import com.carrotzmarket.db.transaction.ProductTransactionEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Column;
@@ -52,6 +55,9 @@ public class ProductEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ProductStatus status;
+
+    @OneToOne(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    private ProductTransactionEntity transaction;
 
     // Getters and Setters
     public Long getId() {

--- a/db/src/main/java/com/carrotzmarket/db/transaction/ProductTransactionEntity.java
+++ b/db/src/main/java/com/carrotzmarket/db/transaction/ProductTransactionEntity.java
@@ -1,11 +1,14 @@
 package com.carrotzmarket.db.transaction;
 
+import com.carrotzmarket.db.product.ProductEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -26,7 +29,9 @@ public class ProductTransactionEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long productId;
+    @OneToOne
+    @JoinColumn(name = "product_id")
+    private ProductEntity product;
 
     private Long sellerId;
 


### PR DESCRIPTION
## 추가 사항
- PRODUCT 테이블과 연결하여 PRODUCT_TRANSACTION 테이블에서 상품 상태를 관리하도록 연관관계 설정
- PRODUCT 테이블의 데이터 삭제 시 PRODUCT_TRANSACTION 테이블 데이터도 함께 삭제되도록 ON DELETE CASCADE 설정
- 거래 내역 상태 변경 기능 추가
  - 거래 내역은 판매자만 변경할 수 있도록 검증 로직 추가 (권한이 없을 경우 예외 발생)
  - 거래 내역 상태 변경 시 PRODUCT 테이블의 상태도 동기화되도록 메서드 작성
- 거래 요청 시 상품 정보가 없을 경우 예외를 던지도록 로직 수정

## 실행
### Product 테이블
![image](https://github.com/user-attachments/assets/1b7e677a-bc84-49fe-9371-e1b03d568000)

<br>

### 존재하지 않은 상품에 대해 거래 요청을 하면 예외가 발생한다.
![image](https://github.com/user-attachments/assets/a997c4e4-a6b7-4826-b621-0558ac469fc0)
![image](https://github.com/user-attachments/assets/da56bf13-70fd-4fac-bf34-d2a753481cfd)

<br>

### 정상 요청시 거래 내역 생성
![image](https://github.com/user-attachments/assets/d009c3a9-1a78-4d99-b542-81a3a65454c3)
![image](https://github.com/user-attachments/assets/d826e4f0-8ac3-4841-9619-33e502f0a8ed)

<br>

### 거래 내역 상태 수정 - 상품의 판매자가 아닐 경우 예외 발생
![image](https://github.com/user-attachments/assets/2b5f70ba-03ba-42c6-b3de-9ad86e8b11bb)
![image](https://github.com/user-attachments/assets/89b050c4-b9a9-4d69-87e7-b5807d411562)

<br>

### 거래 내역 상태 수정
![image](https://github.com/user-attachments/assets/14e331fc-fcf9-4546-b19b-6973bfe10563)
![image](https://github.com/user-attachments/assets/c8bcd521-27b6-4f3c-97e1-c27a41a4e97d)
![image](https://github.com/user-attachments/assets/b1e03938-3caf-4dbb-8db0-189bcff2b4ac)
![image](https://github.com/user-attachments/assets/a739cb92-ce6f-4533-807e-d84ed771f534)


