### PR TITLE
Fix/kan 97

### DIFF
--- a/api/src/main/java/com/carrotzmarket/api/domain/favoriteProduct/repository/FavoriteProductRepository.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/favoriteProduct/repository/FavoriteProductRepository.java
@@ -1,7 +1,11 @@
 package com.carrotzmarket.api.domain.favoriteProduct.repository;
 
 import com.carrotzmarket.db.favoriteProduct.FavoriteProductEntity;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,6 +13,13 @@ import java.util.Optional;
 
 @Repository
 public interface FavoriteProductRepository extends JpaRepository<FavoriteProductEntity, Long> {
+
     Optional<FavoriteProductEntity> findByUserIdAndProductId(Long userId, Long productId);
+
     List<FavoriteProductEntity> findByUserId(Long userId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM FavoriteProductEntity f WHERE f.product.id = :productId")
+    void deleteByProductId(@Param("productId") Long productId);
 }

--- a/api/src/main/java/com/carrotzmarket/api/domain/favoriteProduct/repository/FavoriteProductRepository.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/favoriteProduct/repository/FavoriteProductRepository.java
@@ -23,3 +23,4 @@ public interface FavoriteProductRepository extends JpaRepository<FavoriteProduct
     @Query("DELETE FROM FavoriteProductEntity f WHERE f.product.id = :productId")
     void deleteByProductId(@Param("productId") Long productId);
 }
+

--- a/api/src/main/java/com/carrotzmarket/api/domain/product/controller/ProductController.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/product/controller/ProductController.java
@@ -49,6 +49,7 @@ public class ProductController {
         return ResponseEntity.ok(result);
     }
 
+
     @GetMapping("/{id}/manner-temperature")
     public ResponseEntity<Map<String, Object>> getSellerMannerTemperatureAndOtherProducts(@PathVariable Long id) {
         Map<String, Object> response = productService.getSellerMannerTemperature(id);

--- a/api/src/main/java/com/carrotzmarket/api/domain/product/service/ProductService.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/product/service/ProductService.java
@@ -92,8 +92,10 @@ public class ProductService {
 
 
     public void deleteProduct(Long id) {
+        favoriteProductRepository.deleteByProductId(id);
+
         ProductEntity product = productRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Product not found with ID: " + id));
+                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
 
         productRepository.delete(product);
     }

--- a/api/src/main/java/com/carrotzmarket/api/domain/product/service/ProductService.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/product/service/ProductService.java
@@ -460,3 +460,4 @@ public class ProductService {
                 .collect(Collectors.toList());
     }
 }
+

--- a/api/src/main/java/com/carrotzmarket/api/domain/product/service/ProductService.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/product/service/ProductService.java
@@ -300,10 +300,15 @@ public class ProductService {
         UserEntity seller = userRepository.findById(sellerId)
                 .orElseThrow(() -> new IllegalArgumentException("판매자를 찾을 수 없습니다."));
 
+        Double mannerTemperature = userRepository.findMannerTemperatureById(sellerId)
+                .orElseThrow(() -> new IllegalArgumentException("판매자의 매너 온도를 찾을 수 없습니다."));
+
+
         SellerProfileDto sellerProfile = new SellerProfileDto(
                 seller.getId(),
                 seller.getLoginId(),
-                seller.getProfileImageUrl()
+                seller.getProfileImageUrl(),
+                mannerTemperature
         );
 
         List<ProductEntity> otherProducts = productRepository.findByUserId(sellerId)

--- a/api/src/main/java/com/carrotzmarket/api/domain/user/dto/SellerProfileDto.java
+++ b/api/src/main/java/com/carrotzmarket/api/domain/user/dto/SellerProfileDto.java
@@ -11,4 +11,5 @@ public class SellerProfileDto {
     private Long userId;
     private String loginId;
     private String profileImageUrl;
+    private Double mannerTemperature;
 }


### PR DESCRIPTION
관심 상품에 등록되어있는 상품 삭제할 때 500 오류 발생해서 상품 삭제 시 관심 상품도 함께 삭제되도록 수정했습니다. seller-info 조회할 때 매너온도 필드 추가해 함께 나타나도록 수정했습니다. 그 아래에 매너 온도만 조회하는 부분은 일단 삭제하지 않고 남겨두었습니다. 필요하면 추후에 완전히 삭제하도록 하겠습니다.